### PR TITLE
fix: declare `matches`

### DIFF
--- a/blacklist-server/index.js
+++ b/blacklist-server/index.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 const {
   DiagnosticSeverity,
@@ -16,7 +17,8 @@ const getBlacklisted = (text) => {
   ]
   const regex = new RegExp(`\\b(${blacklist.join('|')})\\b`, 'gi')
   const results = []
-  regex.lastIndex = 0
+  let matches
+
   while ((matches = regex.exec(text)) && results.length < 100) {
     results.push({
       value: matches[0],


### PR DESCRIPTION
`matches` was not declared and therefore this wouldn't run in strict environments, or ESM.

Since `vim-ale` doesn't give errors when a program doesn't run, and I didn't have my normal linter setup because "it's just a quick test"... ugh... it became a very, very nasty silent error.